### PR TITLE
Change 'Usage text'

### DIFF
--- a/lib/Parse/RecDescent.pm
+++ b/lib/Parse/RecDescent.pm
@@ -24,7 +24,7 @@ sub import  # IMPLEMENT PRECOMPILER BEHAVIOUR UNDER:
 
     if ($file eq '-' && $line == 0)
     {
-        _die("Usage: perl -MLocalTest - <grammarfile> <classname>")
+        _die("Usage: perl -MParse::RecDescent - <grammarfile> <classname> [runtimeclassname]")
             unless @ARGV >= 2 and $ARGV <= 3;
 
         my ($sourcefile, $class, $runtime_class) = @ARGV;


### PR DESCRIPTION
If the package is loaded with -MParse::RecDescent the 'dying' message
now reads
  Usage: perl -MParse::RecDescent - <grammerfile> <classname> [runtimeclassname]
instead
  Usage: perl -MLocalTest - <grammerfile> <classname> [runtimeclassname]